### PR TITLE
Fixes for zabbix ssl connectivity

### DIFF
--- a/src/main/java/org/openbaton/monitoring/agent/ZabbixMonitoringAgent.java
+++ b/src/main/java/org/openbaton/monitoring/agent/ZabbixMonitoringAgent.java
@@ -265,11 +265,12 @@ public class ZabbixMonitoringAgent extends MonitoringPlugin {
 
     private void init() throws RemoteException {
         loadProperties();
-        String zabbixIp = properties.getProperty("zabbix-ip");
+        String zabbixHost = properties.getProperty("zabbix-host");
         String zabbixPort = properties.getProperty("zabbix-port");
         String username = properties.getProperty("user-zbx");
         String password = properties.getProperty("password-zbx");
-        zabbixSender = new ZabbixSender(zabbixIp,zabbixPort,username,password);
+        Boolean zabbixSsl = Boolean.parseBoolean(properties.getProperty("zabbix-ssl", "false"));
+        zabbixSender = new ZabbixSender(zabbixHost,zabbixPort, zabbixSsl,username,password);
         zabbixApiManager= new ZabbixApiManager(zabbixSender);
         String nrsp=properties.getProperty("notification-receiver-server-port","8010");
         notificationReceiverServerPort=Integer.parseInt(nrsp);

--- a/src/main/java/org/openbaton/monitoring/agent/ZabbixSender.java
+++ b/src/main/java/org/openbaton/monitoring/agent/ZabbixSender.java
@@ -35,21 +35,23 @@ public class ZabbixSender implements RestSender{
     private Logger log = LoggerFactory.getLogger(this.getClass());
     private Gson mapper=new GsonBuilder().setPrettyPrinting().create();
     private String TOKEN;
-    private String zabbixIp;
+    private String zabbixHost;
     private String zabbixPort;
     private String zabbixURL;
     private String username;
     private String password;
 
-    public ZabbixSender(String zabbixIp,String zabbixPort, String username, String password){
-        this.zabbixIp=zabbixIp;
+    public ZabbixSender(String zabbixHost,String zabbixPort, Boolean zabbixSsl, String username, String password){
+        this.zabbixHost =zabbixHost;
         this.username=username;
         this.password=password;
+        String protocol = zabbixSsl ? "https://" : "http://";
+
         if (zabbixPort == null || zabbixPort.equals("")) {
-            zabbixURL = "http://" + zabbixIp + "/zabbix/api_jsonrpc.php";
+            zabbixURL = protocol + zabbixHost + "/zabbix/api_jsonrpc.php";
         }
         else {
-            zabbixURL = "http://" + zabbixIp + ":" + zabbixPort + "/zabbix/api_jsonrpc.php";
+            zabbixURL = protocol + zabbixHost + ":" + zabbixPort + "/zabbix/api_jsonrpc.php";
             this.zabbixPort=zabbixPort;
         }
     }
@@ -78,7 +80,7 @@ public class ZabbixSender implements RestSender{
             /*
 			 * authenticate again, because the last token is expired
 			 */
-                authenticate(zabbixIp, username, password);
+                authenticate(zabbixHost, username, password);
                 body = prepareJson(content, method);
                 jsonResponse = doRestCallWithJson(zabbixURL, body, HttpMethod.POST, "application/json-rpc");
             }
@@ -150,8 +152,8 @@ public class ZabbixSender implements RestSender{
         return false;
     }
 
-    public void authenticate(String zabbixIp, String username, String password) throws MonitoringException {
-        this.zabbixIp = zabbixIp;
+    public void authenticate(String zabbixHost, String username, String password) throws MonitoringException {
+        this.zabbixHost = zabbixHost;
         this.username = username;
         this.password = password;
 

--- a/src/test/java/org/openbaton/monitoring/agent/test/ZabbixApiManagerTest.java
+++ b/src/test/java/org/openbaton/monitoring/agent/test/ZabbixApiManagerTest.java
@@ -49,7 +49,8 @@ public class ZabbixApiManagerTest {
                 properties.load(is);
             }
         }
-        ZabbixSender zabbixSender = new ZabbixSender(properties.getProperty("zabbix-ip"),properties.getProperty("zabbix-port"),properties.getProperty("user"), properties.getProperty("password"));
+        ZabbixSender zabbixSender = new ZabbixSender(properties.getProperty("zabbix-host"),properties.getProperty("zabbix-port"),
+                Boolean.parseBoolean(properties.getProperty("zabbix-ssl", "false")), properties.getProperty("user"), properties.getProperty("password"));
         zabbixApiManager= new ZabbixApiManager(zabbixSender);
     }
 


### PR DESCRIPTION
Changed zabbix-ip field to zabbix-host, using it for both ip or hostname.
Added filed zabbix-ssl (boolean property) - can be empty (default: false). If true in the config file https protocol is used instead of http.
