### PR TITLE
chore: Use --no-cache-dir flag to pip in Dockerfiles, to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN ./gradlew build -x test
 
 FROM openjdk:8-jre-alpine
 COPY --from=builder /project/build/libs/*.jar /plugin-monitoring-zabbix.jar
-RUN apk add -u --no-cache python py-pip &&pip install supervisor &&mkdir -p /var/log/openbaton
+RUN apk add -u --no-cache python py-pip && pip install --no-cache-dir supervisor && mkdir -p /var/log/openbaton
 COPY --from=builder /project/gradle/gradle/scripts/docker/supervisord.conf /etc/supervisord.conf
 COPY --from=builder /project/src/main/resources/plugin.conf.properties /etc/openbaton/openbaton-plugin-monitoring-zabbix.properties
 ENV ZABBIX_PLUGIN_IP=localhost


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>